### PR TITLE
Add basic Last Sunday calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>The Last Sunday</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@types/node": "^24.1.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1670,6 +1671,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -3914,6 +3925,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,85 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
-import './App.css'
+
+interface UserData {
+  name: string
+  age: number
+}
+
+const STORAGE_KEY = 'last-sunday-user'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [user, setUser] = useState<UserData | null>(null)
+  const [name, setName] = useState('')
+  const [age, setAge] = useState<number | ''>('')
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as UserData
+        setUser(parsed)
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!name || age === '' || age < 0) return
+    const data = { name, age: Number(age) }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    setUser(data)
+  }
+
+  function handleReset() {
+    localStorage.removeItem(STORAGE_KEY)
+    setUser(null)
+    setName('')
+    setAge('')
+  }
+
+  if (!user) {
+    return (
+      <div className="flex min-h-svh flex-col items-center justify-center gap-4">
+        <h1 className="text-2xl font-semibold">The Last Sunday</h1>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="rounded border px-3 py-2 text-black"
+            required
+          />
+          <input
+            type="number"
+            placeholder="Your age"
+            min="0"
+            value={age}
+            onChange={(e) => setAge(e.target.valueAsNumber)}
+            className="rounded border px-3 py-2 text-black"
+            required
+          />
+          <div className="text-center">
+            <Button type="submit">Save</Button>
+          </div>
+        </form>
+      </div>
+    )
+  }
+
+  const lifeExpectancy = 80
+  const sundaysLeft = Math.max(0, Math.round((lifeExpectancy - user.age) * 52))
 
   return (
-    <>
-      <div className="flex min-h-svh flex-col items-center justify-center">
-        <Button>Click me</Button>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-    </>
+    <div className="flex min-h-svh flex-col items-center justify-center gap-4">
+      <h1 className="text-2xl font-semibold">
+        Hello {user.name}, you have {sundaysLeft} Sundays left
+      </h1>
+      <Button onClick={handleReset}>Change info</Button>
+    </div>
   )
 }
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,13 @@
-import path from "path"
 import { defineConfig } from 'vite'
-import tailwindcss from "@tailwindcss/vite"
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { fileURLToPath, URL } from 'url'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- collect name and age from the user
- store info in `localStorage`
- show remaining Sundays using life expectancy of 80 years
- fix react-refresh eslint issue
- use `url` utilities in Vite config
- update title and add `@types/node`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886054e7f388327a5027e934131afca